### PR TITLE
Issue #31 : Need a descriptive error message if node settings are not correctly configured

### DIFF
--- a/org.nodeclipse.ui/src/org/nodeclipse/ui/preferences/PreferenceConstants.java
+++ b/org.nodeclipse.ui/src/org/nodeclipse/ui/preferences/PreferenceConstants.java
@@ -12,5 +12,7 @@ public class PreferenceConstants {
 	public static final String EXPRESS_PATH = "express_pass";
 	public static final String EXPRESS_VERSION = "express_version";
 	public static final String COMPLETIONS_JSON_PATH = "completionsjson_path";
+	public static final String PREFERENCES_PAGE = "org.nodeclipse.ui.preferences.NodePreferencePage";
+	
 	
 }


### PR DESCRIPTION
A new dialog will be shown to the user if the node location is not correctly configured. Clicking on 'Open Preferences' will directly take the user to the preferences page.

Sample dialog shown to the user - 

![image](https://f.cloud.github.com/assets/2890490/493116/545a7992-bb1e-11e2-9aff-612cee7c3ad2.png)
