### PR TITLE
org.nodeclipse.bundle.express, was: doctype 5 is depricated; should use doctype html

### DIFF
--- a/org.nodeclipse.bundle.express/express/bin/express
+++ b/org.nodeclipse.bundle.express/express/bin/express
@@ -74,7 +74,7 @@ var users = [
  */
 
 var jadeLayout = [
-    'doctype 5'
+    'doctype html'
   , 'html'
   , '  head'
   , '    title= title'


### PR DESCRIPTION
Doctype 5 is deprecated by jade and won't work.  For some reason this file was in .gitignore, so I added using -f because I think it must be a mistake.  If that's wrong please let me know what I should do - I'm new here but I'm trying to help.
