### PR TITLE
Nodeclipse issue #189 - workaround for node issue 25266

### DIFF
--- a/chromedevtools/plugins/org.chromium.sdk/src/org/chromium/sdk/internal/v8native/DebuggerCommand.java
+++ b/chromedevtools/plugins/org.chromium.sdk/src/org/chromium/sdk/internal/v8native/DebuggerCommand.java
@@ -33,6 +33,7 @@ public enum DebuggerCommand {
   BREAK("break"),
   EXCEPTION("exception"),
   AFTER_COMPILE("afterCompile"),
+  COMPILE_ERROR("compileError"),
   SCRIPT_COLLECTED("scriptCollected"),
   ;
 

--- a/chromedevtools/plugins/org.chromium.sdk/src/org/chromium/sdk/internal/v8native/DefaultResponseHandler.java
+++ b/chromedevtools/plugins/org.chromium.sdk/src/org/chromium/sdk/internal/v8native/DefaultResponseHandler.java
@@ -79,6 +79,27 @@ public class DefaultResponseHandler {
     command2EventProcessorGetter.put(DebuggerCommand.BREAK /* event */, bppGetter);
     command2EventProcessorGetter.put(DebuggerCommand.EXCEPTION /* event */, bppGetter);
 
+    // Nodeclipse Issue 189 / node issue 25266
+    // Treat the "compileError" event as if it were
+    // the "afterCompile" event...
+    // This is a workaround for an apparent problem in node
+    // that was introduced in v0.11.14. The reported problem
+    // is that when a new script is required and compiled, 
+    // the compileError event is generated instead of the 
+    // afterCompile event.
+    // If this does in fact turn out to be a node issue,
+    // then presumably this workaround would be version-specific,
+    // and would only need to be activated for certain versions
+    // of node.
+    command2EventProcessorGetter.put(DebuggerCommand.COMPILE_ERROR /* event */,
+        new ProcessorGetter() {
+      @Override
+      AfterCompileProcessor get(DefaultResponseHandler instance) {
+        return instance.afterCompileProcessor;
+      }
+    });
+    // <end> Nodeclipse Issue 189 / node issue 25266
+
     command2EventProcessorGetter.put(DebuggerCommand.AFTER_COMPILE /* event */,
         new ProcessorGetter() {
       @Override


### PR DESCRIPTION
Pull request that addresses Nodeclipse issue #189.

This is a workaround for node issue joyent/node#25358, where node seems to be generating 'compileError' events instead of 'afterCompile' events.  This causes Nodeclipse to miss the chance to process new scripts as they are pulled into a running application, as Nodeclipse is listening for the afterCompile events.

As discussed in Nodeclipse issue #189, if this does in fact turn out to be a node issue, then presumably this workaround would be version-specific, and would only need to be activated for certain versions of node.



