### PR TITLE
[SECURITY] Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/org.nodeclipse.site.test/pom.xml
+++ b/org.nodeclipse.site.test/pom.xml
@@ -20,7 +20,7 @@
 		<repository>
 			<id>eexplorer</id>
 			<layout>p2</layout>
-			<url>http://culmat.github.io/eExplorer/updatesite/</url>
+			<url>https://culmat.github.io/eExplorer/updatesite/</url>
 		</repository>
 	</repositories>
 

--- a/org.nodeclipse.site/pom.xml
+++ b/org.nodeclipse.site/pom.xml
@@ -24,7 +24,7 @@
 		<repository>
 			<id>jshint-eclipse</id>
 			<layout>p2</layout>
-			<url>http://github.eclipsesource.com/jshint-eclipse/updates/</url>
+			<url>https://github.eclipsesource.com/jshint-eclipse/updates/</url>
 		</repository>
 
 
@@ -32,14 +32,14 @@
 		<repository>
 			<id>org.dadacoalition.yedit</id>
 			<layout>p2</layout>
-			<url>http://dadacoalition.org/yedit</url>
+			<url>https://dadacoalition.org/yedit</url>
 		</repository>
 		<!--
 		-->
 		<repository>
 			<id>git-addon</id>
 			<layout>p2</layout>
-			<url>http://www.nodeclipse.org/git/addon/</url>
+			<url>https://www.nodeclipse.org/git/addon/</url>
 		</repository>
 
 
@@ -48,18 +48,18 @@
 		<repository>
 			<id>plugin-list</id>
 			<layout>p2</layout>
-			<url>http://www.nodeclipse.org/updates/pluginslist/</url>
+			<url>https://www.nodeclipse.org/updates/pluginslist/</url>
 		</repository>
 		-->
 		<repository>
 			<id>winterwell.markdown</id>
 			<layout>p2</layout>
-			<url>http://www.nodeclipse.org/updates/markdown/</url>
+			<url>https://www.nodeclipse.org/updates/markdown/</url>
 		</repository>
 		<repository>
 			<id>gfm.viewer</id>
 			<layout>p2</layout>
-			<url>http://dl.bintray.com/satyagraha/generic/1.9.3/</url>
+			<url>https://dl.bintray.com/satyagraha/generic/1.9.3/</url>
 		</repository>
 		<!-- [ERROR] Internal error: java.lang.RuntimeException: org.eclipse.equinox.p2.core.ProvisionException: Unable to connect to repository https://svn.codespot.com/a/eclipselabs.org/restclient-tool/trunk/eclipse/update/artifacts.xml: Connection to https://svn.codespot.com refused: Connection timed out: connect -> [Help 1]
 		<repository>
@@ -71,29 +71,29 @@
 		<repository>
 			<id>startexplorer</id>
 			<layout>p2</layout>
-			<url>http://basti1302.github.com/startexplorer/update/</url>
+			<url>https://basti1302.github.com/startexplorer/update/</url>
 		</repository>
 		<repository>
 			<id>Icons-Editor</id>
 			<layout>p2</layout>
-			<url>http://eclipse-icons-editor.eclipselabs.org.codespot.com/git/site/org.eclipse_icons.editor.site/</url>
+			<url>https://eclipse-icons-editor.eclipselabs.org.codespot.com/git/site/org.eclipse_icons.editor.site/</url>
 		</repository>
 		<repository>
 			<id>jeeeyul</id>
 			<layout>p2</layout>
-			<url>http://jeeeyul.github.io/update/</url>
+			<url>https://jeeeyul.github.io/update/</url>
 		</repository>
 		<!--
 		<repository>
 			<id>Regular-Expression</id>
 			<layout>p2</layout>
-			<url>http://zapletnev.github.io/eclipse-regexp/repository/</url>
+			<url>https://zapletnev.github.io/eclipse-regexp/repository/</url>
 		</repository>
 		-->
 		<repository>
 			<id>net.jumperz.app.MMonjaDB</id>
 			<layout>p2</layout>
-			<url>http://www.jumperz.net/update/</url>
+			<url>https://www.jumperz.net/update/</url>
 		</repository>
 		<repository>
 			<id>shelled</id>
@@ -117,47 +117,47 @@
 		<repository>
 			<id>less</id>
 			<layout>p2</layout>
-			<url>http://www.normalesup.org/~simonet/soft/ow/update/</url>
+			<url>https://www.normalesup.org/~simonet/soft/ow/update/</url>
 		</repository>
 		 -->
 		<repository>
 			<id>ansy-console</id>
 			<layout>p2</layout>
-			<url>http://www.mihai-nita.net/eclipse</url>
+			<url>https://www.mihai-nita.net/eclipse</url>
 		</repository>
 		<repository>
 			<id>grep-console</id>
 			<layout>p2</layout>
-			<url>http://eclipse.schedenig.name</url>
+			<url>https://eclipse.schedenig.name</url>
 		</repository>
 		<repository>
 			<id>editbox</id>
 			<layout>p2</layout>
-			<url>http://nodeclipse.github.io/updates/editbox-0.70.0/</url>
+			<url>https://nodeclipse.github.io/updates/editbox-0.70.0/</url>
 		</repository>
 		<!--
 		<repository>
 			<id>axmor-typescript</id>
 			<layout>p2</layout>
-			<url>http://axmor.bitbucket.org/typecs/stable/update-site/</url>
+			<url>https://axmor.bitbucket.org/typecs/stable/update-site/</url>
 		</repository>
 		-->
 		<repository>
 			<id>io.emmet.eclipse</id>
 			<layout>p2</layout>
-			<url>http://emmet.io/eclipse/updates/</url>
+			<url>https://emmet.io/eclipse/updates/</url>
 		</repository>
 		<!--
 		<repository>
 			<id>Rinzo-XML-Editor</id>
 			<layout>p2</layout>
-			<url>http://editorxml.sourceforge.net/updates/</url>
+			<url>https://editorxml.sourceforge.net/updates/</url>
 		</repository>
 		-->
 		<repository>
 			<id>zipeditor</id>
 			<layout>p2</layout>
-			<url>http://nodeclipse.github.io/updates/zipeditor/</url>
+			<url>https://nodeclipse.github.io/updates/zipeditor/</url>
 		</repository>
 
 
@@ -166,7 +166,7 @@
 			<id>jdt.spelling.feature</id>
 			<layout>p2</layout>
 			<!-- <url>http://www.stuarthendren.net/update/</url>  -->
-			<url>http://jdt.spelling.s3-website-us-east-1.amazonaws.com</url>
+			<url>https://jdt.spelling.s3-website-us-east-1.amazonaws.com</url>
 		</repository>
 
 
@@ -174,29 +174,29 @@
 		<repository>
 			<id>it.unibz.instasearch.feature.indigo</id>
 			<layout>p2</layout>
-			<url>http://dl.bintray.com/ajermakovics/InstaSearch/</url>
+			<url>https://dl.bintray.com/ajermakovics/InstaSearch/</url>
 		</repository>
 		<repository>
 			<id>com.xored.glance</id>
 			<layout>p2</layout>
-			<url>http://eclipse-glance.googlecode.com/svn/site/</url>
+			<url>https://eclipse-glance.googlecode.com/svn/site/</url>
 		</repository>
 		<!--
 		<repository>
 			<id>nodeclipse.github.io</id>
 			<layout>p2</layout>
-			<url>http://nodeclipse.github.io/updates/eclipse-color-theme/</url>
+			<url>https://nodeclipse.github.io/updates/eclipse-color-theme/</url>
 		</repository>
 		-->
 		<repository>
 			<id>com.github.eclipsecolortheme.feature</id>
 			<layout>p2</layout>
-			<url>http://eclipse-color-theme.github.com/update</url>
+			<url>https://eclipse-color-theme.github.com/update</url>
 		</repository>
 		<repository>
 			<id>net.jeeeyul.eclipse.themes.updatesite</id>
 			<layout>p2</layout>
-			<url>http://eclipse.jeeeyul.net/update/</url>
+			<url>https://eclipse.jeeeyul.net/update/</url>
 		</repository>
 		<repository>
 			<id>moonrise.com.github.eclipseuitheme.themes.feature</id>
@@ -209,7 +209,7 @@
 		<repository>
 			<id>coffeescript-eclipse</id>
 			<layout>p2</layout>
-			<url>http://dl.bintray.com/nodeclipse/CoffeeScriptEditor/0.4.0-201403250304/</url>
+			<url>https://dl.bintray.com/nodeclipse/CoffeeScriptEditor/0.4.0-201403250304/</url>
 		</repository>
 
 
@@ -217,28 +217,28 @@
 		<repository>
 			<id>EclipseRunner</id>
 			<layout>p2</layout>
-			<url>http://eclipserunnerplugin.googlecode.com/svn/trunk/EclipseRunnerSite</url>
+			<url>https://eclipserunnerplugin.googlecode.com/svn/trunk/EclipseRunnerSite</url>
 		</repository>
 		<repository>
 			<id>practicallymacro</id>
 			<layout>p2</layout>
-			<url>http://puremvcnotificationviewer.googlecode.com/svn/trunk/PracticallyMacroGoogleUpdateSite</url>
+			<url>https://puremvcnotificationviewer.googlecode.com/svn/trunk/PracticallyMacroGoogleUpdateSite</url>
 		</repository>
 		<repository>
 			<id>SelectionExplorer</id>
 			<layout>p2</layout>
-			<url>http://sandipchitaleseclipseplugins.googlecode.com/svn/trunk/SelectionExplorerUpdateSite</url>
+			<url>https://sandipchitaleseclipseplugins.googlecode.com/svn/trunk/SelectionExplorerUpdateSite</url>
 		</repository>
 		<repository>
 			<id>OpenClosedProjectsFeature</id>
 			<layout>p2</layout>
-			<url>http://sandipchitaleseclipseplugins.googlecode.com/svn/trunk/OpenClosedProjectsFeatureUpdateSite/</url>
+			<url>https://sandipchitaleseclipseplugins.googlecode.com/svn/trunk/OpenClosedProjectsFeatureUpdateSite/</url>
 		</repository>
 		<!-- can't be fully bundled
 		<repository>
 			<id>Closure-by-Vincent.Simonet</id>
 			<layout>p2</layout>
-			<url>http://www.normalesup.org/~simonet/soft/ow/update/</url>
+			<url>https://www.normalesup.org/~simonet/soft/ow/update/</url>
 		</repository>
 		-->
 
@@ -247,7 +247,7 @@
 		<repository>
 			<id>fail-back</id>
 			<layout>p2</layout>
-			<url>http://dl.bintray.com/nodeclipse/nodeclipse/0.15/</url>
+			<url>https://dl.bintray.com/nodeclipse/nodeclipse/0.15/</url>
 		</repository>
 
 
@@ -256,7 +256,7 @@
 		<repository>
 			<id>winterwell.markdown</id>
 			<layout>p2</layout>
-			<url>http://winterwell.com/software/updatesite/</url>
+			<url>https://winterwell.com/software/updatesite/</url>
 		</repository>
 		-->
 
@@ -264,12 +264,12 @@
 		<repository>
 			<id>Closure-by-Vincent.Simonet.p2f</id>
 			<layout>p2</layout>
-			<url>http://www.normalesup.org/~simonet/soft/ow/update/</url>
+			<url>https://www.normalesup.org/~simonet/soft/ow/update/</url>
 		</repository>
 		<repository>
 			<id>quicksearch</id>
 			<layout>p2</layout>
-			<url>http://dist.springsource.com/release/TOOLS/update/e4.3/</url>
+			<url>https://dist.springsource.com/release/TOOLS/update/e4.3/</url>
 		</repository>
 		 -->
 	</repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
 		<repository>
 			<id>kepler</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/kepler</url>
+			<url>https://download.eclipse.org/releases/kepler</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
[![mitm_build](https://user-images.githubusercontent.com/1323708/59226671-90645200-8ba1-11e9-8ab3-39292bef99e9.jpeg)](https://medium.com/@jonathan.leitschuh/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)

- [Want to take over the Java ecosystem? All you need is a MITM!](https://medium.com/@jonathan.leitschuh/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)
- [Update: Want to take over the Java ecosystem? All you need is a MITM!](https://medium.com/bugbountywriteup/update-want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-d069d253fe23?source=friends_link&sk=8c8e52a7d57b98d0b7e541665688b454)

---

This is a security fix for a  vulnerability in your [Apache Maven](https://maven.apache.org/) `pom.xml` file(s).

The build files indicate that this project is resolving dependencies over HTTP instead of HTTPS.
This leaves your build vulnerable to allowing a [Man in the Middle](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) (MITM) attackers to execute arbitrary code on your or your computer or CI/CD system.

This vulnerability has a CVSS v3.0 Base Score of [8.1/10](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H).

[POC code](https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/) has existed since 2014 to maliciously compromise a JAR file in-flight.
MITM attacks against HTTP are [increasingly common](https://security.stackexchange.com/a/12050), for example [Comcast is known to have done it to their own users](https://thenextweb.com/insights/2017/12/11/comcast-continues-to-inject-its-own-code-into-websites-you-visit/#).

This contribution is a part of a submission to the [GitHub Security Lab](https://securitylab.github.com/) Bug Bounty program.

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by [LGTM.com](https://lgtm.com) using this [CodeQL Query](https://lgtm.com/rules/1511115648721/).

As of September 2019 LGTM.com and Semmle are [officially a part of GitHub](https://github.blog/2019-09-18-github-welcomes-semmle/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [LGTM App](https://github.com/marketplace/lgtm).

I'm not an employee of GitHub nor of Semmle, I'm simply a user of [LGTM.com](https://lgtm.com) and an open-source security researcher.

## Source

Yes, this contribution was automatically generated, however, the code to generate this PR was lovingly hand crafted to bring this security fix to your repository.

The source code that generated and submitted this PR can be found here:
[JLLeitschuh/bulk-security-pr-generator](https://github.com/JLLeitschuh/bulk-security-pr-generator)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/bulk-security-pr-generator
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin 
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Tracking

All PR's generated as part of this fix are tracked here: 
https://github.com/JLLeitschuh/bulk-security-pr-generator/issues/2